### PR TITLE
Allow getting/setting a component in a single update

### DIFF
--- a/lib/ecsx/component.ex
+++ b/lib/ecsx/component.ex
@@ -96,6 +96,7 @@ defmodule ECSx.Component do
       def update(entity_id, fun) when is_function(fun, 1) do
         value = get_one(entity_id)
         ECSx.Base.update(@table_name, entity_id, fun.(value), @component_opts)
+        value
       end
 
       def get_one(key, default \\ :raise), do: ECSx.Base.get_one(@table_name, key, default)

--- a/lib/ecsx/component.ex
+++ b/lib/ecsx/component.ex
@@ -93,6 +93,11 @@ defmodule ECSx.Component do
       def update(entity_id, value) when ecsx_type_guard(value),
         do: ECSx.Base.update(@table_name, entity_id, value, @component_opts)
 
+      def update(entity_id, fun) when is_function(fun, 1) do
+        value = get_one(entity_id)
+        ECSx.Base.update(@table_name, entity_id, fun.(value), @component_opts)
+      end
+
       def get_one(key, default \\ :raise), do: ECSx.Base.get_one(@table_name, key, default)
 
       def get_all, do: ECSx.Base.get_all(@table_name)

--- a/test/ecsx/component_test.exs
+++ b/test/ecsx/component_test.exs
@@ -12,9 +12,13 @@ defmodule ECSx.ComponentTest do
 
       assert "Andy" == StringComponent.get_one(11)
 
-      StringComponent.update(11, fn (str) -> str <> " Alice" end)
+      StringComponent.update(11, "Alice")
 
-      assert "Andy Alice" == StringComponent.get_one(11)
+      assert "Alice" == StringComponent.get_one(11)
+
+      StringComponent.update(11, fn (str) -> str <> " Bob" end)
+
+      assert "Alice Bob" == StringComponent.get_one(11)
 
       for {id, foo} <- [{1, "A"}, {2, "B"}, {3, "C"}],
           do: StringComponent.add(id, foo)
@@ -32,7 +36,7 @@ defmodule ECSx.ComponentTest do
       assert Enum.sort(all_components) == [
                {1, "A"},
                {2, "B"},
-               {11, "Andy Alice"}
+               {11, "Alice Bob"}
              ]
     end
 

--- a/test/ecsx/component_test.exs
+++ b/test/ecsx/component_test.exs
@@ -12,6 +12,10 @@ defmodule ECSx.ComponentTest do
 
       assert "Andy" == StringComponent.get_one(11)
 
+      StringComponent.update(11, fn (str) -> str <> " Alice" end)
+
+      assert "Andy Alice" == StringComponent.get_one(11)
+
       for {id, foo} <- [{1, "A"}, {2, "B"}, {3, "C"}],
           do: StringComponent.add(id, foo)
 
@@ -28,7 +32,7 @@ defmodule ECSx.ComponentTest do
       assert Enum.sort(all_components) == [
                {1, "A"},
                {2, "B"},
-               {11, "Andy"}
+               {11, "Andy Alice"}
              ]
     end
 

--- a/test/ecsx/component_test.exs
+++ b/test/ecsx/component_test.exs
@@ -16,7 +16,7 @@ defmodule ECSx.ComponentTest do
 
       assert "Alice" == StringComponent.get_one(11)
 
-      StringComponent.update(11, fn (str) -> str <> " Bob" end)
+      assert "Alice" == StringComponent.update(11, fn (str) -> str <> " Bob" end)
 
       assert "Alice Bob" == StringComponent.get_one(11)
 


### PR DESCRIPTION
Calling `update/2` with a function allows getting and setting a component in one call, like so:

```elixir
MyComponent.update(123, fn (old_val) -> old_val + 1 end)
```