### PR TITLE
Remove non-unique component option

### DIFF
--- a/guides/ecs_design.md
+++ b/guides/ecs_design.md
@@ -22,3 +22,64 @@ For example:
 * Entities with `Speed` Components should have their locations regularly updated according to the speed and direction
 * We can create a `Move` System which reads the `Speed` and `Direction` Components, calculates how far the car has moved since the last server tick, and updates the Entity's `XCoordinate` and/or `YCoordinate` Component accordingly.
 * The System will run every tick, only considering Entities which have a `Speed` Component
+
+## one-to-many associations
+
+At some point, you might find yourself thinking of adding multiple Components of the same type to a
+single Entity.  We'll call this a "one-to-many" association - as in, one Entity, many Components.
+For example:
+
+Let's say you have a fantasy game where the hero wields a weapon in one hand, and a shield in the
+other hand.  At first, you create a Component for each
+
+```elixir
+Weapon.add(hero_entity, "Longsword")
+Shield.add(hero_entity, "Buckler")
+```
+
+and move on to other features.  However, later on you decide to implement a dual-wielding mechanic
+where the hero can wield two swords at a time.  You briefly consider creating a new Component type
+called `OffhandWeapon` to go alongside the primary `Weapon`, but then remember that eventually the
+hero will encounter monsters with more than two arms!  Also there is a feature request for weapons
+to be magically enchanted, and eventually you'd also like equipment to lose durability over time and
+require repairs at the blacksmith.  So, creating a new Component type for each weapon slot is only
+a temporary workaround which is not a very robust solution.
+
+The ideal solution here is to think about the weapons not as Components, but as separate Entities.
+When the hero equips a sword, create a new entity reference for that sword, and reference back
+to the hero entity with one of the sword's Components.
+
+```elixir
+sword_entity = Ecto.UUID.generate()
+Description.add(sword_entity, "Longsword")
+EquippedBy.add(sword_entity, hero_entity)
+```
+
+Now if the hero gets a second sword, we can repeat the process:
+
+```elixir
+another_sword_entity = Ecto.UUID.generate()
+Description.add(another_sword_entity, "Shortsword")
+EquippedBy.add(another_sword_entity, hero_entity)
+```
+
+Fetching a list of weapons equipped by the hero can then be done with `EquippedBy.search(hero_entity)`
+
+To implement weapon durability:
+
+```elixir
+Durability.add(sword_entity, 150)
+Durability.add(another_sword_entity, 75)
+```
+
+Implementing magic enchantments presents the same situation:  we could add a Component to the sword,
+but this only works for one simple enchantment per weapon.  In order to allow multiple enchantments
+per weapon, with arbitrary enchantment complexity, we should think about each enchantment as an
+Entity.
+
+```elixir
+enchantment_entity = Ecto.UUID.generate()
+Description.add(enchantment_entity, "Firaga")
+EnchantTarget.add(enchantment_entity, sword_entity)
+```
+

--- a/guides/tutorial/web_frontend_liveview.md
+++ b/guides/tutorial/web_frontend_liveview.md
@@ -60,9 +60,9 @@ defmodule ShipWeb.GameLive do
 
   def handle_info(:load_player_info, socket) do
     # This will run every 50ms to keep the client assigns updated
-    x = XPosition.get_one(socket.assigns.player_entity)
-    y = YPosition.get_one(socket.assigns.player_entity)
-    hp = HullPoints.get_one(socket.assigns.player_entity)
+    x = XPosition.get(socket.assigns.player_entity)
+    y = YPosition.get(socket.assigns.player_entity)
+    hp = HullPoints.get(socket.assigns.player_entity)
 
     {:noreply, assign(socket, x_coord: x, y_coord: y, current_hp: hp)}
   end
@@ -290,9 +290,9 @@ defmodule ShipWeb.GameLive do
 
   # Our previous :load_player_info handler becomes a shared helper for the new handlers
   defp assign_player_ship(socket) do
-    x = XPosition.get_one(socket.assigns.player_entity)
-    y = YPosition.get_one(socket.assigns.player_entity)
-    hp = HullPoints.get_one(socket.assigns.player_entity)
+    x = XPosition.get(socket.assigns.player_entity)
+    y = YPosition.get(socket.assigns.player_entity)
+    hp = HullPoints.get(socket.assigns.player_entity)
 
     assign(socket, x_coord: x, y_coord: y, current_hp: hp)
   end
@@ -458,10 +458,10 @@ defmodule ShipWeb.GameLive do
   end
 
   defp assign_player_ship(socket) do
-    x = XPosition.get_one(socket.assigns.player_entity)
-    y = YPosition.get_one(socket.assigns.player_entity)
-    hp = HullPoints.get_one(socket.assigns.player_entity)
-    image = ImageFile.get_one(socket.assigns.player_entity)
+    x = XPosition.get(socket.assigns.player_entity)
+    y = YPosition.get(socket.assigns.player_entity)
+    hp = HullPoints.get(socket.assigns.player_entity)
+    image = ImageFile.get(socket.assigns.player_entity)
 
     assign(socket, x_coord: x, y_coord: y, current_hp: hp, player_ship_image_file: image)
   end
@@ -475,9 +475,9 @@ defmodule ShipWeb.GameLive do
 
   defp all_ships do
     for {ship, _hp} <- HullPoints.get_all() do
-      x = XPosition.get_one(ship)
-      y = YPosition.get_one(ship)
-      image = ImageFile.get_one(ship)
+      x = XPosition.get(ship)
+      y = YPosition.get(ship)
+      image = ImageFile.get(ship)
       {ship, x, y, image}
     end
   end
@@ -595,9 +595,9 @@ defmodule Ship.Systems.Attacking do
   end
 
   defp spawn_projectile(self, target) do
-    attack_damage = AttackDamage.get_one(self)
-    x = XPosition.get_one(self)
-    y = YPosition.get_one(self)
+    attack_damage = AttackDamage.get(self)
+    x = XPosition.get(self)
+    y = YPosition.get(self)
     # Armor reduction should wait until impact to be calculated
     cannonball_entity = Ecto.UUID.generate()
 
@@ -639,7 +639,7 @@ defmodule Ship.Systems.Projectile do
     projectiles = IsProjectile.get_all()
       
     Enum.each(projectiles, fn projectile ->
-      case ProjectileTarget.get_one(projectile, nil) do
+      case ProjectileTarget.get(projectile, nil) do
         nil ->
           # The target has already been destroyed
           destroy_projectile(projectile)
@@ -666,15 +666,15 @@ defmodule Ship.Systems.Projectile do
   end
 
   defp get_distance_to_target(projectile, target) do
-    target_x = XPosition.get_one(target)
-    target_y = YPosition.get_one(target)
-    target_dx = XVelocity.get_one(target)
-    target_dy = YVelocity.get_one(target)
+    target_x = XPosition.get(target)
+    target_y = YPosition.get(target)
+    target_dx = XVelocity.get(target)
+    target_dy = YVelocity.get(target)
     target_next_x = target_x + target_dx
     target_next_y = target_y + target_dy
 
-    x = XPosition.get_one(projectile)
-    y = YPosition.get_one(projectile)
+    x = XPosition.get(projectile)
+    y = YPosition.get(projectile)
 
     dx = target_next_x - x
     dy = target_next_y - y
@@ -688,11 +688,11 @@ defmodule Ship.Systems.Projectile do
   end
 
   defp damage_target(projectile, target) do
-    damage = ProjectileDamage.get_one(projectile)
-    reduction_from_armor = ArmorRating.get_one(target)
+    damage = ProjectileDamage.get(projectile)
+    reduction_from_armor = ArmorRating.get(target)
     final_damage_amount = damage - reduction_from_armor
 
-    target_current_hp = HullPoints.get_one(target)
+    target_current_hp = HullPoints.get(target)
     target_new_hp = target_current_hp - final_damage_amount
 
     HullPoints.update(target, target_new_hp)
@@ -786,9 +786,9 @@ defmodule Ship.GameLive do
   defp assign_projectiles(socket) do
     projectiles =
       for projectile <- IsProjectile.get_all() do
-        x = XPosition.get_one(projectile)
-        y = YPosition.get_one(projectile)
-        image = ImageFile.get_one(projectile)
+        x = XPosition.get(projectile)
+        y = YPosition.get(projectile)
+        image = ImageFile.get(projectile)
         {projectile, x, y, image}
       end
 

--- a/guides/upgrade_guide.md
+++ b/guides/upgrade_guide.md
@@ -1,5 +1,15 @@
 # Upgrade Guide
 
+## 0.4 to 0.5
+
+Non-unique Component types are no longer allowed.  Setting the `:unique` option from within a Component
+module now has no effect.  If you are currently using non-unique Component types in your application,
+you must replace them with Entities as described in the [one_to_many guide](ecs_design.html#one-to-many-associations).
+
+Component read/write changes:
+
+  * `MyComponent.get_one/1` should be renamed to `MyComponent.get/1`
+
 ## 0.3.x to 0.4
 
 In `manager.ex`:

--- a/lib/ecsx/base.ex
+++ b/lib/ecsx/base.ex
@@ -6,22 +6,6 @@ defmodule ECSx.Base do
   def add(component_type, id, value, opts) do
     persist = Keyword.get(opts, :persist, false)
 
-    if Keyword.get(opts, :log_edits) do
-      Logger.debug("#{component_type} add #{inspect(id)}: #{inspect(value)}")
-    end
-
-    if Keyword.get(opts, :index) do
-      index_table = Module.concat(component_type, "Index")
-      :ets.insert(index_table, {value, id, persist})
-    end
-
-    :ets.insert(component_type, {id, value, persist})
-    :ok
-  end
-
-  def add_new(component_type, id, value, opts) do
-    persist = Keyword.get(opts, :persist, false)
-
     case :ets.lookup(component_type, id) do
       [] ->
         if Keyword.get(opts, :log_edits) do

--- a/lib/ecsx/base.ex
+++ b/lib/ecsx/base.ex
@@ -6,17 +6,6 @@ defmodule ECSx.Base do
   def add(component_type, id, value, opts) do
     persist = Keyword.get(opts, :persist, false)
 
-    if Keyword.get(opts, :log_edits) do
-      Logger.debug("#{component_type} add #{inspect(id)}: #{inspect(value)}")
-    end
-
-    :ets.insert(component_type, {id, value, persist})
-    :ok
-  end
-
-  def add_new(component_type, id, value, opts) do
-    persist = Keyword.get(opts, :persist, false)
-
     case :ets.lookup(component_type, id) do
       [] ->
         if Keyword.get(opts, :log_edits) do
@@ -55,13 +44,13 @@ defmodule ECSx.Base do
     end
   end
 
-  def get_one(component_type, entity_id, default) do
+  def get(component_type, entity_id, default) do
     case :ets.lookup(component_type, entity_id) do
       [] ->
         case default do
           :raise ->
             raise ECSx.NoResultsError,
-              message: "`get_one` expects one result, got 0",
+              message: "`get` expects one result, got 0",
               entity_id: entity_id
 
           other ->
@@ -70,11 +59,6 @@ defmodule ECSx.Base do
 
       [component] ->
         elem(component, 1)
-
-      multiple_results ->
-        raise ECSx.MultipleResultsError,
-          message: "`get_one` expects one result, got #{length(multiple_results)}",
-          entity_id: entity_id
     end
   end
 
@@ -131,30 +115,12 @@ defmodule ECSx.Base do
     :ok
   end
 
-  def remove_one(component_type, entity_id, value, opts) do
-    case :ets.match_object(component_type, {entity_id, value, :_}) do
-      [] ->
-        raise ECSx.NoResultsError,
-          message: "no value found for {#{inspect(entity_id)}, #{inspect(value)}}",
-          entity_id: entity_id
-
-      [entity | _rest] ->
-        if Keyword.get(opts, :log_edits) do
-          Logger.debug("#{component_type} remove_one #{inspect(entity_id)}: #{inspect(value)}")
-        end
-
-        :ets.delete_object(component_type, entity)
-    end
-
-    :ok
-  end
-
   def exists?(component_type, entity_id) do
     :ets.member(component_type, entity_id)
   end
 
-  def init(table_name, table_type, concurrency) do
-    :ets.new(table_name, [:named_table, table_type, concurrency])
+  def init(table_name, concurrency) do
+    :ets.new(table_name, [:named_table, :set, concurrency])
     :ok
   end
 end

--- a/lib/ecsx/component.ex
+++ b/lib/ecsx/component.ex
@@ -59,6 +59,21 @@ defmodule ECSx.Component do
           )
       end
 
+      # Eventually remove this
+      case Keyword.get(opts, :unique) do
+        true ->
+          IO.warn(
+            "Component option `:unique` no longer has any effect",
+            Macro.Env.stacktrace(env)
+          )
+
+        false ->
+          raise(ArgumentError, "Component option `unique: false` is no longer allowed")
+
+        nil ->
+          :ok
+      end
+
       def init, do: ECSx.Base.init(@table_name, @concurrency)
 
       def load(component), do: ECSx.Base.load(@table_name, component)

--- a/lib/ecsx/component.ex
+++ b/lib/ecsx/component.ex
@@ -62,10 +62,9 @@ defmodule ECSx.Component do
       # Eventually remove this
       case Keyword.get(opts, :unique) do
         true ->
-          IO.warn(
-            "Component option `:unique` no longer has any effect",
-            Macro.Env.stacktrace(env)
-          )
+          msg = "Component option `:unique` no longer has any effect"
+          IO.warn(msg, Macro.Env.stacktrace(env))
+          :ok
 
         false ->
           raise(ArgumentError, "Component option `unique: false` is no longer allowed")

--- a/lib/ecsx/component.ex
+++ b/lib/ecsx/component.ex
@@ -63,7 +63,7 @@ defmodule ECSx.Component do
       case Keyword.get(opts, :unique) do
         true ->
           msg = "Component option `:unique` no longer has any effect"
-          IO.warn(msg, Macro.Env.stacktrace(env))
+          IO.warn(msg, Macro.Env.stacktrace(__ENV__))
           :ok
 
         false ->

--- a/lib/mix/tasks/ecsx.gen.component.ex
+++ b/lib/mix/tasks/ecsx.gen.component.ex
@@ -42,11 +42,11 @@ defmodule Mix.Tasks.Ecsx.Gen.Component do
     |> Mix.raise()
   end
 
-  def run([component_type_name, value_type]) do
+  def run([component_type_name, value_type | opts]) do
     value_type = validate(value_type)
     {opts, _, _} = OptionParser.parse(opts, strict: [index: :boolean])
     Helpers.inject_component_module_into_manager(component_type_name)
-    create_component_file(component_type_name, value_type)
+    create_component_file(component_type_name, value_type, opts)
   end
 
   defp message_with_help(message) do
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Ecsx.Gen.Component do
   defp validate(_),
     do: Mix.raise("Invalid value type. Possible types are: #{inspect(@valid_value_types)}")
 
-  defp create_component_file(component_type_name, value_type) do
+  defp create_component_file(component_type_name, value_type, opts) do
     filename = Macro.underscore(component_type_name)
     target = "lib/#{Helpers.otp_app()}/components/#{filename}.ex"
     source = Application.app_dir(:ecsx, "/priv/templates/component.ex")

--- a/lib/mix/tasks/ecsx.gen.component.ex
+++ b/lib/mix/tasks/ecsx.gen.component.ex
@@ -16,10 +16,6 @@ defmodule Mix.Tasks.Ecsx.Gen.Component do
     * float
     * integer
 
-  By default, new component types are generated with `unique: true`, which allows an entity to have at most one component of this type at any given time.  To override this, use the `--no-unique` flag:
-
-      $ mix ecsx.gen.component Friendship binary --no-unique
-
   """
 
   use Mix.Task
@@ -41,11 +37,10 @@ defmodule Mix.Tasks.Ecsx.Gen.Component do
     |> Mix.raise()
   end
 
-  def run([component_type_name, value_type | opts]) do
+  def run([component_type_name, value_type]) do
     value_type = validate(value_type)
-    {opts, _, _} = OptionParser.parse(opts, strict: [unique: :boolean])
     Helpers.inject_component_module_into_manager(component_type_name)
-    create_component_file(component_type_name, value_type, opts)
+    create_component_file(component_type_name, value_type)
   end
 
   defp message_with_help(message) do
@@ -66,14 +61,13 @@ defmodule Mix.Tasks.Ecsx.Gen.Component do
   defp validate(_),
     do: Mix.raise("Invalid value type. Possible types are: #{inspect(@valid_value_types)}")
 
-  defp create_component_file(component_type_name, value_type, opts) do
+  defp create_component_file(component_type_name, value_type) do
     filename = Macro.underscore(component_type_name)
     target = "lib/#{Helpers.otp_app()}/components/#{filename}.ex"
     source = Application.app_dir(:ecsx, "/priv/templates/component.ex")
 
     binding = [
       app_name: Helpers.root_module(),
-      unique: Keyword.get(opts, :unique, true),
       component_type: component_type_name,
       value: value_type
     ]

--- a/priv/templates/component.ex
+++ b/priv/templates/component.ex
@@ -3,6 +3,5 @@ defmodule <%= app_name %>.Components.<%= component_type %> do
   Documentation for <%= component_type %> components.
   """
   use ECSx.Component,
-    value: <%= inspect(value) %>,
-    unique: <%= unique %>
+    value: <%= inspect(value) %>
 end

--- a/test/ecsx/base_test.exs
+++ b/test/ecsx/base_test.exs
@@ -3,26 +3,14 @@ defmodule ECSx.BaseTest do
 
   alias ECSx.Base
 
-  describe "#add/4" do
-    setup :setup_nonunique_component
-
-    test "successful" do
-      assert :ok == Base.add(:nonunique_component, 123, "test", [])
-      assert :ok == Base.add(:nonunique_component, 123, "test2", [])
-      assert :ok == Base.add(:nonunique_component, 123, "test2", [])
-
-      assert :ets.lookup(:nonunique_component, 123) == [
-               {123, "test", false},
-               {123, "test2", false}
-             ]
-    end
+  setup do
+    :ets.new(:sample_component, [:named_table])
+    :ok
   end
 
-  describe "#add_new/4" do
-    setup :setup_component
-
+  describe "#add/4" do
     test "successful" do
-      Base.add_new(:sample_component, 123, "test", [])
+      Base.add(:sample_component, 123, "test", [])
 
       assert :ets.lookup(:sample_component, 123) == [{123, "test", false}]
     end
@@ -33,14 +21,12 @@ defmodule ECSx.BaseTest do
       assert_raise ECSx.AlreadyExistsError,
                    "`add` expects component to not exist yet from entity 123\n",
                    fn ->
-                     Base.add_new(:sample_component, 123, "test", [])
+                     Base.add(:sample_component, 123, "test", [])
                    end
     end
   end
 
   describe "#update/4" do
-    setup :setup_component
-
     test "successful" do
       :ets.insert(:sample_component, {123, "test", false})
       Base.update(:sample_component, 123, "test2", [])
@@ -56,40 +42,25 @@ defmodule ECSx.BaseTest do
     end
   end
 
-  describe "#get_one/2" do
-    setup [:setup_component, :setup_nonunique_component]
-
+  describe "#get/2" do
     test "when component exists" do
       :ets.insert(:sample_component, {123, "shazam"})
 
-      assert Base.get_one(:sample_component, 123, []) == "shazam"
+      assert Base.get(:sample_component, 123, []) == "shazam"
     end
 
     test "returns default when component does not exist" do
-      assert Base.get_one(:sample_component, 123, :some_val) == :some_val
+      assert Base.get(:sample_component, 123, :some_val) == :some_val
     end
 
     test "raises when component does not exist" do
       assert_raise ECSx.NoResultsError,
-                   "`get_one` expects one result, got 0 from entity 123\n",
-                   fn -> Base.get_one(:sample_component, 123, :raise) end
-    end
-
-    test "raises if multiple results are found" do
-      :ets.insert(:nonunique_component, {123, "uno"})
-      :ets.insert(:nonunique_component, {123, "dos"})
-
-      message = "`get_one` expects one result, got 2 from entity 123\n"
-
-      assert_raise ECSx.MultipleResultsError, message, fn ->
-        Base.get_one(:nonunique_component, 123, [])
-      end
+                   "`get` expects one result, got 0 from entity 123\n",
+                   fn -> Base.get(:sample_component, 123, :raise) end
     end
   end
 
   describe "#get_all/1" do
-    setup :setup_component
-
     test "when components exist" do
       :ets.insert(:sample_component, {123, "foo"})
       :ets.insert(:sample_component, {456, "bar"})
@@ -102,24 +73,7 @@ defmodule ECSx.BaseTest do
     end
   end
 
-  describe "#get_all/2" do
-    setup :setup_nonunique_component
-
-    test "when components exist" do
-      :ets.insert(:nonunique_component, {123, "A"})
-      :ets.insert(:nonunique_component, {123, "B"})
-
-      assert Base.get_all(:nonunique_component, 123) == ["A", "B"]
-    end
-
-    test "for zero components" do
-      assert Base.get_all(:nonunique_component, 123) == []
-    end
-  end
-
   describe "#between/3" do
-    setup :setup_component
-
     test "integers" do
       :ets.insert(:sample_component, {123, 1, false})
       :ets.insert(:sample_component, {234, 2, false})
@@ -132,8 +86,6 @@ defmodule ECSx.BaseTest do
   end
 
   describe "#at_least/2" do
-    setup :setup_component
-
     test "integers" do
       :ets.insert(:sample_component, {123, 1, true})
       :ets.insert(:sample_component, {234, 2, true})
@@ -146,8 +98,6 @@ defmodule ECSx.BaseTest do
   end
 
   describe "#at_most/2" do
-    setup :setup_component
-
     test "integers" do
       :ets.insert(:sample_component, {123, 1, true})
       :ets.insert(:sample_component, {234, 2, true})
@@ -160,9 +110,7 @@ defmodule ECSx.BaseTest do
   end
 
   describe "#remove/2" do
-    setup [:setup_component, :setup_nonunique_component]
-
-    test "one component from unique type" do
+    test "test" do
       :ets.insert(:sample_component, {123, "uno", false})
       :ets.insert(:sample_component, {456, "dos", false})
 
@@ -171,58 +119,14 @@ defmodule ECSx.BaseTest do
       assert :ets.lookup(:sample_component, 123) == []
       assert :ets.lookup(:sample_component, 456) == [{456, "dos", false}]
     end
-
-    test "multiple components from nonunique type" do
-      :ets.insert(:nonunique_component, {123, "uno", false})
-      :ets.insert(:nonunique_component, {123, "dos", false})
-      :ets.insert(:nonunique_component, {456, "tres", false})
-
-      Base.remove(:nonunique_component, 123, [])
-
-      assert :ets.lookup(:nonunique_component, 123) == []
-      assert :ets.lookup(:nonunique_component, 456) == [{456, "tres", false}]
-    end
-  end
-
-  describe "#remove_one/3" do
-    setup :setup_nonunique_component
-
-    test "removes one of several components" do
-      :ets.insert(:nonunique_component, {123, "uno", false})
-      :ets.insert(:nonunique_component, {123, "dos", false})
-
-      Base.remove_one(:nonunique_component, 123, "uno", [])
-
-      assert :ets.lookup(:nonunique_component, 123) == [{123, "dos", false}]
-    end
-
-    test "raises when doesn't exist" do
-      assert_raise ECSx.NoResultsError,
-                   "no value found for {123, \"uno\"} from entity 123\n",
-                   fn ->
-                     Base.remove_one(:nonunique_component, 123, "uno", [])
-                   end
-    end
   end
 
   describe "#exists?/2" do
-    setup :setup_component
-
     test "test" do
       :ets.insert(:sample_component, {123, "test", false})
 
       assert Base.exists?(:sample_component, 123)
       refute Base.exists?(:sample_component, 456)
     end
-  end
-
-  defp setup_component(_) do
-    :ets.new(:sample_component, [:named_table])
-    :ok
-  end
-
-  defp setup_nonunique_component(_) do
-    :ets.new(:nonunique_component, [:named_table, :bag])
-    :ok
   end
 end

--- a/test/ecsx/base_test.exs
+++ b/test/ecsx/base_test.exs
@@ -4,7 +4,12 @@ defmodule ECSx.BaseTest do
   alias ECSx.Base
 
   setup do
-    :ets.new(:sample_component, [:named_table])
+    table_name = :sample_component
+    :ets.new(table_name, [:named_table])
+
+    index_table = Module.concat(table_name, "Index")
+    :ets.new(index_table, [:named_table, :bag])
+
     :ok
   end
 
@@ -26,7 +31,7 @@ defmodule ECSx.BaseTest do
     end
 
     test "with index" do
-      assert :ok == Base.add_new(:sample_component, 123, "test", index: true)
+      assert :ok == Base.add(:sample_component, 123, "test", index: true)
 
       index_table = Module.concat(:sample_component, "Index")
 

--- a/test/ecsx/component_test.exs
+++ b/test/ecsx/component_test.exs
@@ -10,7 +10,7 @@ defmodule ECSx.ComponentTest do
 
       assert :ok == StringComponent.add(11, "Andy")
 
-      assert "Andy" == StringComponent.get_one(11)
+      assert "Andy" == StringComponent.get(11)
 
       for {id, foo} <- [{1, "A"}, {2, "B"}, {3, "C"}],
           do: StringComponent.add(id, foo)
@@ -35,7 +35,6 @@ defmodule ECSx.ComponentTest do
     defmodule BadReadConcurrency do
       use ECSx.Component,
         value: :integer,
-        unique: true,
         read_concurrency: :invalid
     end
 

--- a/test/mix/tasks/ecsx.gen.component_test.exs
+++ b/test/mix/tasks/ecsx.gen.component_test.exs
@@ -136,7 +136,6 @@ defmodule Mix.Tasks.Ecsx.Gen.ComponentTest do
                  \"\"\"
                  use ECSx.Component,
                    value: :binary,
-                   unique: true,
                    index: true
                end
                """

--- a/test/mix/tasks/ecsx.gen.component_test.exs
+++ b/test/mix/tasks/ecsx.gen.component_test.exs
@@ -24,28 +24,7 @@ defmodule Mix.Tasks.Ecsx.Gen.ComponentTest do
                  Documentation for FooComponent components.
                  \"\"\"
                  use ECSx.Component,
-                   value: :binary,
-                   unique: true
-               end
-               """
-    end)
-  end
-
-  test "generates module for non-unique component type" do
-    Mix.Project.in_project(:my_app, ".", fn _module ->
-      Mix.Tasks.Ecsx.Gen.Component.run(["FooComponent", "binary", "--no-unique"])
-
-      component_file = File.read!("lib/my_app/components/foo_component.ex")
-
-      assert component_file ==
-               """
-               defmodule MyApp.Components.FooComponent do
-                 @moduledoc \"\"\"
-                 Documentation for FooComponent components.
-                 \"\"\"
-                 use ECSx.Component,
-                   value: :binary,
-                   unique: false
+                   value: :binary
                end
                """
     end)

--- a/test/support/integer_component.ex
+++ b/test/support/integer_component.ex
@@ -1,5 +1,4 @@
 defmodule ECSx.IntegerComponent do
   use ECSx.Component,
-    value: :integer,
-    unique: true
+    value: :integer
 end

--- a/test/support/string_component.ex
+++ b/test/support/string_component.ex
@@ -1,5 +1,4 @@
 defmodule ECSx.StringComponent do
   use ECSx.Component,
-    value: :binary,
-    unique: true
+    value: :binary
 end


### PR DESCRIPTION
Resolves #52 

* [x] Remove functionality
* [x] Add guide on using Entities instead
* [x] Link to aforementioned guide in the 0.4 -> 0.5 upgrade guide
* [x] Update tests
* [x] Warn/raise if `:unique` option is still used